### PR TITLE
Add docker config.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+docker-compose.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:alpine
+MAINTAINER moenka <moenka@10forge.org>
+
+ENV SCRUMBLR_PORT="8080"
+ENV SCRUMBLR_BASEURL="/"
+ENV SCRUMBLR_REDIS_URL="redis://redis"
+ENV SCRUMBLR_REDIS_PORT="6379"
+
+WORKDIR /srv/scrumblr
+COPY . /srv/scrumblr
+
+RUN npm install
+
+ENTRYPOINT /usr/local/bin/node server.js \
+           --port ${SCRUMBLR_PORT} \
+           --baseurl ${SCRUMBLR_BASEURL} \
+           --redis ${SCRUMBLR_REDIS_URL}:${SCRUMBLR_REDIS_PORT}
+

--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,8 @@ use scrumblr
 
 if you'd like to use scrumblr go to [scrumblr.ca](http://scrumblr.ca). new boards are made simply by modifying the url to something unique. e.g. your team could use a shared board at: *http://scrumblr.ca/thisisoursecretboard23423242*
 
+if you want to host a on-demand version for e.g. meetups or presentation you can run `docker-compose --build -d`. the application is then reachable via `localhost:7000`.
+
 alternatively, you can follow the instructions below to setup scrumblr yourself. it is very simple -- it just uses redis and node.js.
 
 if you are a developer, please fork and submit changes/fixes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+---
+version: '3'
+services:
+  redis:
+    image: redis:alpine
+    volumes:
+    - 'redis:/data'
+  server:
+    build: ./
+    image: scrumblr
+    links:
+    - redis
+    ports:
+    - '7000:8080'
+volumes:
+  redis:
+


### PR DESCRIPTION
Make the application run as a docker container. This way a scrumblr instance can be deployed within seconds which is useful for on-demand setups like on meetups or presentation.